### PR TITLE
Port to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ eggs
 parts
 develop-eggs
 .DS_Store
+.idea

--- a/geolucidate/__init__.py
+++ b/geolucidate/__init__.py
@@ -10,4 +10,4 @@ u'<a href="http://maps.google.com/maps?q=58.235278%2C-77.333333+%2858147N%2F0772
 
 """
 
-from functions import replace, google_maps_link
+from geolucidate.functions import replace, google_maps_link

--- a/geolucidate/functions.py
+++ b/geolucidate/functions.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-
-import re
 from decimal import Decimal, setcontext, ExtendedContext
-from urllib import urlencode
+
 from geolucidate.parser import parser_re
 from geolucidate.links.google import google_maps_link
 from geolucidate.links.tools import MapLink

--- a/geolucidate/links/tools.py
+++ b/geolucidate/links/tools.py
@@ -1,4 +1,4 @@
-from urllib import urlencode
+from urllib.parse import urlencode
 
 
 def default_link(url, text, title=''):

--- a/geolucidate/parser.py
+++ b/geolucidate/parser.py
@@ -13,7 +13,7 @@ resulted in a rather lengthy and complex regular expression.
 
 import re
 
-parser_re = re.compile(ur"""\b
+parser_re = re.compile(r"""\b
     # Latitude direction, first position: one of N, S, NORTH, SOUTH
     ((?P<latdir>NORTH|SOUTH|[NS])\ ?)?
     # Latitude degrees: two digits 0-90


### PR DESCRIPTION
- Update import paths
- Update urlencode path. Lives under `urllib.parse` now
- Update regEx flags to just `r`. Since Python 3 is unicode by default the `u` flag isn't needed anymore.