### PR TITLE
Bugfix: Pass `query` of type `dict` to urlencode

### DIFF
--- a/geolucidate/constants.py
+++ b/geolucidate/constants.py
@@ -1,0 +1,37 @@
+"""List of Minutes/Seconds Characters for normalization
+
+Was generated with unicodedata.name and unicodedata.char
+and searched for names that include "QUOTATION" and "PRIME"
+"""
+MINUTE_CHARACTERS = {
+    # Quotations
+    "LEFT SINGLE QUOTATION MARK": "‘",
+    "RIGHT SINGLE QUOTATION MARK": "’",
+    "HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT": "❛",
+    "HEAVY SINGLE COMMA QUOTATION MARK ORNAMENT": "❜",
+    "SINGLE HIGH-REVERSED-9 QUOTATION MARK": "‛",
+    # Primes
+    "PRIME": "′",
+    "MODIFIER LETTER PRIME": "ʹ",
+    "REVERSED PRIME": "‵",
+}
+SECOND_CHARACTERS = {
+    # Quotations
+    "LEFT DOUBLE QUOTATION MARK": "“",
+    "RIGHT DOUBLE QUOTATION MARK": "”",
+    "REVERSED DOUBLE PRIME QUOTATION MARK": "〝",
+    "DOUBLE HIGH-REVERSED-9 QUOTATION MARK": "‟",
+    "HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT": "❝",
+    "HEAVY DOUBLE COMMA QUOTATION MARK ORNAMENT": "❞",
+    "DOUBLE PRIME QUOTATION MARK": "〞",
+    "FULLWIDTH QUOTATION MARK": "＂",
+    # Primes
+    "MODIFIER LETTER DOUBLE PRIME": "ʺ",
+    "DOUBLE PRIME": "″",
+    "REVERSED DOUBLE PRIME": "‶",
+}
+
+# Use above dicts to generate RegEx character group string
+# Example Output: MINUTE_CHARACTERS_RE >> "[‘’❛❜‛′ʹ‵]"
+MINUTE_CHARACTERS_RE = '[{}]'.format(''.join(MINUTE_CHARACTERS.values()))
+SECOND_CHARACTERS_RE = '[{}]'.format(''.join(SECOND_CHARACTERS.values()))

--- a/geolucidate/constants.py
+++ b/geolucidate/constants.py
@@ -1,3 +1,6 @@
+import re
+
+
 """List of Minutes/Seconds Characters for normalization
 
 Was generated with unicodedata.name and unicodedata.char
@@ -33,5 +36,5 @@ SECOND_CHARACTERS = {
 
 # Use above dicts to generate RegEx character group string
 # Example Output: MINUTE_CHARACTERS_RE >> "[‘’❛❜‛′ʹ‵]"
-MINUTE_CHARACTERS_RE = '[{}]'.format(''.join(MINUTE_CHARACTERS.values()))
-SECOND_CHARACTERS_RE = '[{}]'.format(''.join(SECOND_CHARACTERS.values()))
+MINUTE_CHARACTERS_RE = re.escape('[{}]'.format(''.join(MINUTE_CHARACTERS.values())))
+SECOND_CHARACTERS_RE = re.escape('[{}]'.format(''.join(SECOND_CHARACTERS.values())))

--- a/geolucidate/functions.py
+++ b/geolucidate/functions.py
@@ -1,12 +1,26 @@
 # -*- coding: utf-8 -*-
+import re
 from decimal import Decimal, setcontext, ExtendedContext
 
 from geolucidate.parser import parser_re
 from geolucidate.links.google import google_maps_link
 from geolucidate.links.tools import MapLink
+from geolucidate.constants import MINUTE_CHARACTERS_RE, SECOND_CHARACTERS_RE
 
 
 setcontext(ExtendedContext)
+
+
+def _normalize_string(string):
+    """ Normalize passed in string before breaking it apart
+
+    Convert all:
+    - forms of single quotes and prime characters to `'`
+    - forms of double quotes and double prime characters to `"`
+    """
+    string = re.sub(MINUTE_CHARACTERS_RE, "'", string)
+    string = re.sub(SECOND_CHARACTERS_RE, '"', string)
+    return string
 
 
 def _cleanup(parts):
@@ -130,6 +144,7 @@ def replace(string, sub_function=google_maps_link()):
         (latitude, longitude) = _convert(*_cleanup(match.groupdict()))
         return sub_function(MapLink(original_string, latitude, longitude))
 
+    string = _normalize_string(string)
     return parser_re.sub(do_replace, string)
 
 
@@ -161,6 +176,7 @@ def get_replacements(string, sub_function=google_maps_link()):
     """
 
     substitutions = {}
+    string = _normalize_string(string)
     matches = parser_re.finditer(string)
 
     for match in matches:

--- a/geolucidate/links/tools.py
+++ b/geolucidate/links/tools.py
@@ -85,7 +85,7 @@ class MapLink(object):
 
         '''
 
-        return link_generator(baseurl + urlencode(params.items()),
+        return link_generator(baseurl + urlencode(params),
                               self.original_string,
                               u"{0} ({1})".format(self.original_string,
                                                   self.coordinates(", ")))

--- a/geolucidate/tests/tests.py
+++ b/geolucidate/tests/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from geolucidate.functions import _cleanup, _convert
+from geolucidate.functions import _cleanup, _normalize_string
 from geolucidate.parser import parser_re
 
 from nose.tools import eq_
@@ -68,8 +68,10 @@ def test_parser():
         ("493616N 1221258W",  ['N', '49', '36', '16', 'W', '122','12', '58']),
         #If the a period is used to separate the degrees and minutes, _and_ the 'seconds' value
         #is only two digits, we now treat it as a proper seconds value rather than a decimal fraction.
-        ("49.36.16N 122.12.58W", ['N', '49', '36', '16', 'W', '122','12', '58'])
-        ]
+        ("49.36.16N 122.12.58W", ['N', '49', '36', '16', 'W', '122','12', '58']),
+        # Strings with Prime and Double Prime Characters
+        ("43°44′30″N 79°22′24″W", ['N', '43', '44', '30', 'W', '79', '22', '24']),
+    ]
 
     for test in values:
         (coord_string, expected) = test
@@ -77,7 +79,8 @@ def test_parser():
 
 
 def check_parser(coord_string, expected):
-    match = parser_re.search(coord_string)
+    normalized = _normalize_string(coord_string)
+    match = parser_re.search(normalized)
     assert match
     result = _cleanup(match.groupdict())
     eq_(result, expected)


### PR DESCRIPTION
The newer version of `urlencode()` expects a subscriptable object. In this case a simple `dict` is fine.