### PR TITLE
Use localcontext

### DIFF
--- a/geolucidate/constants.py
+++ b/geolucidate/constants.py
@@ -36,5 +36,5 @@ SECOND_CHARACTERS = {
 
 # Use above dicts to generate RegEx character group string
 # Example Output: MINUTE_CHARACTERS_RE >> "[‘’❛❜‛′ʹ‵]"
-MINUTE_CHARACTERS_RE = re.escape('[{}]'.format(''.join(MINUTE_CHARACTERS.values())))
-SECOND_CHARACTERS_RE = re.escape('[{}]'.format(''.join(SECOND_CHARACTERS.values())))
+MINUTE_CHARACTERS_RE = '[{}]'.format(re.escape(''.join(MINUTE_CHARACTERS.values())))
+SECOND_CHARACTERS_RE = '[{}]'.format(re.escape(''.join(SECOND_CHARACTERS.values())))

--- a/geolucidate/functions.py
+++ b/geolucidate/functions.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import re
-from decimal import Decimal, setcontext, ExtendedContext
+from decimal import Decimal, ExtendedContext, localcontext
 
 from geolucidate.parser import parser_re
 from geolucidate.links.google import google_maps_link
 from geolucidate.links.tools import MapLink
 from geolucidate.constants import MINUTE_CHARACTERS_RE, SECOND_CHARACTERS_RE
-
-
-setcontext(ExtendedContext)
 
 
 def _normalize_string(string):
@@ -78,44 +75,47 @@ def _convert(latdir, latdeg, latmin, latsec,
     ('50.459167', '-127.460833')
 
     """
-    if (latsec != '00' or longsec != '00'):
-        precision = Decimal('0.000001')
-    elif (latmin != '00' or longmin != '00'):
-        precision = Decimal('0.001')
-    else:
-        precision = Decimal('1')
 
-    latitude = Decimal(latdeg)
-    latmin = Decimal(latmin)
-    latsec = Decimal(latsec)
+    with localcontext(ExtendedContext) as ctx:
+    
+        if (latsec != '00' or longsec != '00'):
+            ctx.prec = Decimal('0.000001')
+        elif (latmin != '00' or longmin != '00'):
+            ctx.prec = Decimal('0.001')
+        else:
+            ctx.prec = Decimal('1')
 
-    longitude = Decimal(longdeg)
-    longmin = Decimal(longmin)
-    longsec = Decimal(longsec)
+        latitude = Decimal(latdeg)
+        latmin = Decimal(latmin)
+        latsec = Decimal(latsec)
 
-    if latsec > 59 or longsec > 59:
-        #Assume that 'seconds' greater than 59 are actually a decimal
-        #fraction of minutes
-        latitude += (latmin +
-                     (latsec / Decimal('100'))) / Decimal('60')
-        longitude += (longmin +
-                  (longsec / Decimal('100'))) / Decimal('60')
-    else:
-        latitude += (latmin +
-                     (latsec / Decimal('60'))) / Decimal('60')
-        longitude += (longmin +
-                      (longsec / Decimal('60'))) / Decimal('60')
+        longitude = Decimal(longdeg)
+        longmin = Decimal(longmin)
+        longsec = Decimal(longsec)
 
-    if latdir == 'S':
-        latitude *= Decimal('-1')
+        if latsec > 59 or longsec > 59:
+            #Assume that 'seconds' greater than 59 are actually a decimal
+            #fraction of minutes
+            latitude += (latmin +
+                         (latsec / Decimal('100'))) / Decimal('60')
+            longitude += (longmin +
+                      (longsec / Decimal('100'))) / Decimal('60')
+        else:
+            latitude += (latmin +
+                         (latsec / Decimal('60'))) / Decimal('60')
+            longitude += (longmin +
+                          (longsec / Decimal('60'))) / Decimal('60')
 
-    if longdir == 'W':
-        longitude *= Decimal('-1')
+        if latdir == 'S':
+            latitude *= Decimal('-1')
 
-    lat_str = str(latitude.quantize(precision))
-    long_str = str(longitude.quantize(precision))
+        if longdir == 'W':
+            longitude *= Decimal('-1')
 
-    return (lat_str, long_str)
+        lat_str = str(latitude.quantize(ctx.prec))
+        long_str = str(longitude.quantize(ctx.prec))
+
+        return (lat_str, long_str)
 
 
 def replace(string, sub_function=google_maps_link()):


### PR DESCRIPTION
`ExtendedContext` in the outer scope was crashing with other libraries.

Also, changed how the minute/second constants were being escaped. The previous approach was also escaping the brackets.